### PR TITLE
Extensible jenkinses declaration

### DIFF
--- a/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/ConfigRepoRule.java
+++ b/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/ConfigRepoRule.java
@@ -150,10 +150,12 @@ public class ConfigRepoRule implements TestRule {
     }
 
     public void writeJenkinses(GitClient git, Map<String, String> jenkinses) throws InterruptedException, IOException {
-        try (PrintStream out = new PrintStream(git.getWorkTree().child("jenkinses").write())) {
-            for (Map.Entry<String, String> j : jenkinses.entrySet()) {
-                out.printf("%s=%s%n", j.getKey(), j.getValue());
-            }
+        FilePath jenkinsesDir = git.getWorkTree().child("jenkinses");
+        for (FilePath filePath : jenkinsesDir.list()) {
+            filePath.delete();
+        }
+        for (Map.Entry<String, String> j : jenkinses.entrySet()) {
+            jenkinsesDir.child(j.getKey()).write("url=" + j.getValue(), "UTF-8");
         }
         git.add("jenkinses");
         git.commit("Update Jenkinses");

--- a/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/NodeSharingJenkinsRule.java
+++ b/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/NodeSharingJenkinsRule.java
@@ -109,7 +109,7 @@ public class NodeSharingJenkinsRule extends JenkinsRule {
 
     protected @Nonnull ShareableNode getNode(String name) {
         Node node = jenkins.getNode(name);
-        assertNotNull("No such node " + name, node);
+        assertNotNull("No such node " + name + ". Have: " + jenkins.getNodes(), node);
         return (ShareableNode) node;
     }
 

--- a/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/PoolTest.java
+++ b/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/PoolTest.java
@@ -117,7 +117,7 @@ public class PoolTest {
 
         assertThat(pool.getConfig().getJenkinses(), containsInAnyOrder(
                 new ExecutorJenkins("https://jenkins1.acme.com", "jenkins1"),
-                new ExecutorJenkins("https://jenkins2.acme.com", "jenkins2")
+                new ExecutorJenkins("https://jenkins1.acme.com:80/context-path", "jenkins2")
         ));
 
         assertFalse(Pool.ADMIN_MONITOR.isActivated());
@@ -254,11 +254,11 @@ public class PoolTest {
 
         Pool.ADMIN_MONITOR.clear();
         cr = j.injectConfigRepo(configRepo.create(getClass().getResource("dummy_config_repo")));
-        cr.getWorkTree().child("jenkinses").delete();
+        cr.getWorkTree().child("jenkinses").deleteRecursive();
         cr.add("*");
         cr.commit("Break it!");
         updater.doRun();
-        assertReports("ERROR: No file named 'jenkinses' found in Config Repository");
+        assertReports("ERROR: No directory named 'jenkinses' found in Config Repository");
 
         //j.interactiveBreak();
 

--- a/jth-tests/src/test/resources/com/redhat/jenkins/nodesharing/dummy_config_repo/jenkinses
+++ b/jth-tests/src/test/resources/com/redhat/jenkins/nodesharing/dummy_config_repo/jenkinses
@@ -1,2 +1,0 @@
-jenkins1=https://jenkins1.acme.com
-jenkins2=https://jenkins2.acme.com

--- a/jth-tests/src/test/resources/com/redhat/jenkins/nodesharing/dummy_config_repo/jenkinses/jenkins1
+++ b/jth-tests/src/test/resources/com/redhat/jenkins/nodesharing/dummy_config_repo/jenkinses/jenkins1
@@ -1,0 +1,1 @@
+url=https://jenkins1.acme.com

--- a/jth-tests/src/test/resources/com/redhat/jenkins/nodesharing/dummy_config_repo/jenkinses/jenkins2
+++ b/jth-tests/src/test/resources/com/redhat/jenkins/nodesharing/dummy_config_repo/jenkinses/jenkins2
@@ -1,0 +1,1 @@
+url=https://jenkins1.acme.com:80/context-path


### PR DESCRIPTION
Use properties files for individual instances to make the format easy to extend in the future.

@pjanouse 