### PR TITLE
Revert "Report empty workload when going to be restarted"

### DIFF
--- a/plugin/src/main/java/com/redhat/jenkins/nodesharingfrontend/WorkloadReporter.java
+++ b/plugin/src/main/java/com/redhat/jenkins/nodesharingfrontend/WorkloadReporter.java
@@ -71,9 +71,10 @@ public class WorkloadReporter extends PeriodicWork {
         }
 
         // Fill only if Jenkins isn't going to restart, report empty workload otherwise
-        if (!Jenkins.getActiveInstance().isQuietingDown() && Jenkins.getActiveInstance().isTerminating()) {
+        Jenkins jenkins = Jenkins.getActiveInstance();
+        if (!jenkins.isQuietingDown() && !jenkins.isTerminating()) {
             // Make sure those scheduled sooner are at the beginning
-            List<Queue.BuildableItem> items = Jenkins.getActiveInstance().getQueue().getBuildableItems();
+            List<Queue.BuildableItem> items = jenkins.getQueue().getBuildableItems();
             for (Queue.Item item : items) {
                 if ("com.redhat.jenkins.nodesharingbackend.ReservationTask".equals(item.task.getClass().getName())) {
                     // TEST HACK: these are not supposed to coexist but they do in jth-tests


### PR DESCRIPTION
This reverts commit c212ae6cafba153d92a2100374dac50cd458872a.

@pjanouse, please have a look. Somehow, this breaks seemingly unrelated tests.