### PR TITLE
Added AsyncResourceDisposer re-scheduling if available

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -29,6 +29,7 @@
   <dependency>
    <groupId>org.jenkins-ci.plugins</groupId>
    <artifactId>resource-disposer</artifactId>
+   <optional>true</optional>
   </dependency>
   <dependency>
    <groupId>org.jenkins-ci.plugins</groupId>

--- a/plugin/src/main/java/com/redhat/jenkins/nodesharingfrontend/SharedNode.java
+++ b/plugin/src/main/java/com/redhat/jenkins/nodesharingfrontend/SharedNode.java
@@ -2,6 +2,7 @@ package com.redhat.jenkins.nodesharingfrontend;
 
 import hudson.Extension;
 import hudson.FilePath;
+import hudson.model.AdministrativeMonitor;
 import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.model.Descriptor.FormException;
@@ -139,13 +140,17 @@ public class SharedNode extends AbstractCloudSlave implements EphemeralNode, Tra
                 }
             }
             // If AsyncResourceDisposer is available, process all Disposables first
-            AsyncResourceDisposer disposer =
-                    (AsyncResourceDisposer) Jenkins.getActiveInstance().getAdministrativeMonitor("AsyncResourceDisposer");
-            if (disposer != null) {
-                // If there is a tracked work to be done yet reschedule all items and wait for 30s
-                if (!disposer.getBacklog().isEmpty())  {
-                    disposer.reschedule();
-                    Thread.sleep(30000);
+            AdministrativeMonitor monitor =  Jenkins.getActiveInstance().getAdministrativeMonitor("AsyncResourceDisposer");
+            if (monitor != null) {
+                try {
+                    AsyncResourceDisposer disposer = (AsyncResourceDisposer) monitor;
+                    // If there is a tracked work to be done yet reschedule all items and wait for 30s
+                    if (!disposer.getBacklog().isEmpty())  {
+                        disposer.reschedule();
+                        Thread.sleep(30000);
+                    }
+                } catch (Throwable e) {
+                    ;   // No-op as we don't get AsyncResourceDisposed
                 }
             }
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
       <dependency>
         <groupId>org.jenkins-ci.plugins.icon-shim</groupId>
         <artifactId>icon-set</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
       </dependency>
 
       <!-- Java modules -->


### PR DESCRIPTION
I'm not much happy with the impl., but options provided by current impl. of AsyncResourceDisposer are *very* limited.
On the other hand I think it is still better to give a chance to process Disposables (with 30s timeout) before node releasing.