### PR TITLE
Update config example to include trailing / on url

### DIFF
--- a/example-config-repo/config
+++ b/example-config-repo/config
@@ -2,7 +2,8 @@
 #
 # Executors will use this to discover the change of an Orchestrator destination.
 # Note the Orchestrator needs this to match its URL, otherwise it will be inactive.
-orchestrator.url=https://dummy.test
+# The trailing / on the url is required.
+orchestrator.url=https://dummy.test/
 
 # Optional: Permit http to be used in url field (Default: false)
 #

--- a/nodesharing-lib/src/main/java/com/redhat/jenkins/nodesharing/ConfigRepo.java
+++ b/nodesharing-lib/src/main/java/com/redhat/jenkins/nodesharing/ConfigRepo.java
@@ -157,6 +157,7 @@ public class ConfigRepo {
                 if (orchestratorUrl == null) {
                     taskLog.error("No " + KEY_CONFIG_ORCHESTRATOR_URL + " specified by Config Repository");
                 } else {
+                    if(!orchestratorUrl.endsWith("/")) orchestratorUrl += "/";
                     try {
                         URL url = new URL(orchestratorUrl);
                         if (!isSafeUrl(url, config)) {


### PR DESCRIPTION
The trailing / is mandatory otherwise the executor will fail to connect to the orchestrator with errors such as:
`java.lang.IllegalArgumentException: Name may not be null`