### PR TITLE
make PermissionGroup public

### DIFF
--- a/nodesharing-lib/src/main/java/com/redhat/jenkins/nodesharing/RestEndpoint.java
+++ b/nodesharing-lib/src/main/java/com/redhat/jenkins/nodesharing/RestEndpoint.java
@@ -108,7 +108,7 @@ public class RestEndpoint {
         return DEFAULT_TIMEOUT;
     }
 
-    private static final PermissionGroup NODE_SHARING_GROUP = new PermissionGroup(RestEndpoint.class, Messages._RestEndpoint_PermissionGroupName());
+    public static final PermissionGroup NODE_SHARING_GROUP = new PermissionGroup(RestEndpoint.class, Messages._RestEndpoint_PermissionGroupName());
     public static final Permission RESERVE = new Permission(NODE_SHARING_GROUP, "Reserve", Messages._RestEndpoint_ReserveDescription(), null, PermissionScope.JENKINS);
 
     // Since the permission is declared in a class that might not be loaded for a while after Jenkins startup or plugin


### PR DESCRIPTION
The PermissionGroup must be a public property of the RestEndpoint class
otherwise it will not be discovered by the Jenkins UI.  When it is private
it is possible to assign the permission with JCasC but not by writing a
tag in $JENKINS_HOME/config.xml (removed on restart as the permission is
not known)

After making this public then the permission is rendered in the Matrix-based
security permission table and can be set via config.xml.