### PR TITLE
per ExecutorJenkins credentials

### DIFF
--- a/backend-plugin/src/main/java/com/redhat/jenkins/nodesharingbackend/Api.java
+++ b/backend-plugin/src/main/java/com/redhat/jenkins/nodesharingbackend/Api.java
@@ -128,7 +128,7 @@ public class Api implements RootAction {
         Pool pool = Pool.getInstance();
         String configRepoUrl = pool.getConfigRepoUrl();
         UtilizeNodeRequest request = new UtilizeNodeRequest(configRepoUrl, version, node.getNodeDefinition());
-        RestEndpoint rest = executor.getRest(configRepoUrl, pool.getCredential());
+        RestEndpoint rest = executor.getRest(configRepoUrl, pool.getExecutorCredential(executor));
         try {
             rest.executeRequest(rest.post("utilizeNode"), request, UtilizeNodeResponse.class);
             return true;
@@ -152,7 +152,7 @@ public class Api implements RootAction {
         Pool pool = Pool.getInstance();
         String configRepoUrl = pool.getConfigRepoUrl();
         ReportUsageRequest request = new ReportUsageRequest(configRepoUrl, version);
-        RestEndpoint rest = owner.getRest(configRepoUrl, pool.getCredential());
+        RestEndpoint rest = owner.getRest(configRepoUrl, pool.getExecutorCredential(owner));
         return rest.executeRequest(rest.post("reportUsage"), request, ReportUsageResponse.class);
     }
 
@@ -177,7 +177,7 @@ public class Api implements RootAction {
         Pool pool = Pool.getInstance();
         String configRepoUrl = pool.getConfigRepoUrl();
         NodeStatusRequest request = new NodeStatusRequest(configRepoUrl, version, nodeName);
-        RestEndpoint rest = jenkins.getRest(configRepoUrl, pool.getCredential());
+        RestEndpoint rest = jenkins.getRest(configRepoUrl, pool.getExecutorCredential(jenkins));
         NodeStatusResponse nodeStatus = rest.executeRequest(rest.post("nodeStatus"), request, NodeStatusResponse.class);
         return nodeStatus.getStatus();
     }

--- a/backend-plugin/src/main/java/com/redhat/jenkins/nodesharingbackend/Pool.java
+++ b/backend-plugin/src/main/java/com/redhat/jenkins/nodesharingbackend/Pool.java
@@ -114,13 +114,14 @@ public class Pool extends GlobalConfiguration {
     }
 
     public @CheckForNull UsernamePasswordCredentials getExecutorCredential(ExecutorJenkins executor) {
-        if(executor.getCredentialId() != null) {
-            LOGGER.finest("using credential with id " + executor.getCredentialId() + " for " + executor.getName());
+        String credentialId = executor.getCredentialId();
+        if(credentialId != null) {
+            LOGGER.finest("using credential with id " + credentialId + " for " + executor.getName());
 
             UsernamePasswordCredentials cred = CredentialsMatchers.firstOrNull(
                     CredentialsProvider.lookupCredentials(UsernamePasswordCredentials.class, Jenkins.getInstance(),
                             ACL.SYSTEM, Collections.<DomainRequirement>emptyList()),
-                    CredentialsMatchers.withId(executor.getCredentialId())
+                    CredentialsMatchers.withId(credentialId)
             );
 
             if(cred == null) {
@@ -134,19 +135,19 @@ public class Pool extends GlobalConfiguration {
         }
 
         if(getConfig().getConfig().containsKey(ConfigRepo.KEY_CREDENTIAL_ID)) {
-            String credentialId = getConfig().getConfig().get(ConfigRepo.KEY_CREDENTIAL_ID);
+            String poolCredentialId = getConfig().getConfig().get(ConfigRepo.KEY_CREDENTIAL_ID);
 
-            LOGGER.finest("using pool wide credential with id " + credentialId + " for " + executor.getName());
+            LOGGER.finest("using pool wide credential with id " + poolCredentialId + " for " + executor.getName());
 
             UsernamePasswordCredentials cred = CredentialsMatchers.firstOrNull(
                     CredentialsProvider.lookupCredentials(UsernamePasswordCredentials.class, Jenkins.getInstance(),
                             ACL.SYSTEM, Collections.<DomainRequirement>emptyList()),
-                    CredentialsMatchers.withId(credentialId)
+                    CredentialsMatchers.withId(poolCredentialId)
             );
 
             if(cred == null) {
                 ADMIN_MONITOR.report(MONITOR_CONTEXT, new AbortException(
-                        "Pool-Wide credentials '" + credentialId + "' for node-sharing not found in Jenkins."
+                        "Pool-Wide credentials '" + poolCredentialId + "' for node-sharing not found in Jenkins."
                 ));
                 return null;
             }

--- a/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/GridTest.java
+++ b/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/GridTest.java
@@ -99,6 +99,37 @@ public class GridTest {
         }
     }
 
+    @Test(timeout = TEST_TIMEOUT)
+    @ExternalFixture(name = "e0", roles = Executor.class,     resource = "executor-smoke.yaml",          injectPlugins = "matrix-auth")
+    @ExternalFixture(name = "e1", roles = Executor.class,     resource = "executor-smoke.yaml",          injectPlugins = "matrix-auth")
+    @ExternalFixture(name = "e2", roles = Executor.class,     resource = "executor-smoke.yaml",          injectPlugins = "matrix-auth")
+    @ExternalFixture(name = "o",  roles = Orchestrator.class, resource = "orchestrator-credential.yaml", injectPlugins = "matrix-auth", setupEnvCredential = false, credentialId = "rest-cred-id")
+    public void smokeNoEnvCredential() throws Exception {
+        ExternalJenkinsRule.Fixture e0 = jcr.fixture("e0");
+        ExternalJenkinsRule.Fixture e1 = jcr.fixture("e1");
+        ExternalJenkinsRule.Fixture e2 = jcr.fixture("e2");
+        jcr.fixture("o"); // Wait for orchestrator to get up
+
+        for (ExternalJenkinsRule.Fixture fixture : Arrays.asList(e0, e1, e2)) {
+            for (int i = 0; ; i++) {
+
+                try {
+                    Thread.sleep(10000);
+                    System.out.println('.');
+                    verifyBuildHasRun(fixture, "sol", "win");
+                    return;
+                } catch (AssertionError ex) {
+                    if (i == 8) {
+                        TimeoutException tex = new TimeoutException("Build not completed in time");
+                        tex.initCause(ex);
+                        throw tex;
+                    }
+                    // Retry
+                }
+            }
+        }
+    }
+
     private void verifyBuildHasRun(ExternalJenkinsRule.Fixture executor, String... jobNames) throws IOException {
         JenkinsServer jenkinsServer = executor.getClient();
         Map<String, Job> jobs = jenkinsServer.getJobs();

--- a/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/PoolTest.java
+++ b/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/PoolTest.java
@@ -137,59 +137,108 @@ public class PoolTest {
         ));
 
         assertFalse(Pool.ADMIN_MONITOR.getErrors().toString(), Pool.ADMIN_MONITOR.isActivated());
+
+        ExecutorJenkins[] jenkinses = pool.getConfig().getJenkinses().toArray(new ExecutorJenkins[0]);
+        UsernamePasswordCredentials creds0 = pool.getExecutorCredential(jenkinses[0]);
+        UsernamePasswordCredentials creds1 = pool.getExecutorCredential(jenkinses[1]);
+
+        assertNotNull(creds0);
+        assertNotNull(creds1);
     }
 
     @Test
-    public void getCredentialsFromJenkins() throws Exception {
+    public void getCredentialsFromJenkinsWithPreference() throws Exception {
         GitClient cr = j.getConfigRepo();
+
         FilePath j2Config = cr.getWorkTree().child("jenkinses").child("jenkins2");
         StringBuilder newConfig = new StringBuilder(j2Config.readToString());
-        newConfig.append("credential_id=rest-cred-id");
+        newConfig.append("credential_id=");
+        newConfig.append(j.getRestCredentialId());
         j2Config.write(newConfig.toString(), Charset.defaultCharset().name());
+
+        FilePath poolConfig = cr.getWorkTree().child("config");
+        newConfig = new StringBuilder(poolConfig.readToString());
+        newConfig.append("credential_id=");
+        newConfig.append(j.getPoolCredentialId());
+        poolConfig.write(newConfig.toString(), Charset.defaultCharset().name());
+
         cr.add("*");
         cr.commit("Setup");
         Updater.getInstance().doRun();
 
         Pool pool = Pool.getInstance();
         Map<String, String> config = pool.getConfig().getConfig();
+        assertTrue(config.containsKey("credential_id"));
+        assertFalse(config.get("credential_id").isEmpty());
 
-        ExecutorJenkins[] jenkinses = pool.getConfig().getJenkinses().toArray(new ExecutorJenkins[0]);
-        assertEquals(2, jenkinses.length);
-        assertNotEquals(jenkinses[0].getCredentialId(), jenkinses[1].getCredentialId());
+        UsernamePasswordCredentials creds1 = pool.getExecutorCredential(pool.getConfig().getJenkinsByName("jenkins1"));
+        UsernamePasswordCredentials creds2 = pool.getExecutorCredential(pool.getConfig().getJenkinsByName("jenkins2"));
 
-        UsernamePasswordCredentials creds0 = pool.getExecutorCredential(jenkinses[0]);
-        UsernamePasswordCredentials creds1 = pool.getExecutorCredential(jenkinses[1]);
-
-        assertNotNull(creds0);
         assertNotNull(creds1);
-        assertNotEquals(creds0, creds1);
+        assertNotNull(creds1);
+
+        assertEquals(creds1, j.getPoolCredential()); // jenkins1 uses pool credential
+        assertEquals(creds2, j.getRestCredential()); // jenkins2 uses it's own (restCredentials)
     }
+
 
     @Test
     public void getCredentialsFromJenkinsBroken() throws Exception {
         GitClient cr = j.getConfigRepo();
+        FilePath j1Config = cr.getWorkTree().child("jenkinses").child("jenkins1");
+        StringBuilder newConfig = new StringBuilder(j1Config.readToString());
+        newConfig.append("credential_id= ");    // space is intentional
+        j1Config.write(newConfig.toString(), Charset.defaultCharset().name());
+
         FilePath j2Config = cr.getWorkTree().child("jenkinses").child("jenkins2");
-        StringBuilder newConfig = new StringBuilder(j2Config.readToString());
+        newConfig = new StringBuilder(j2Config.readToString());
         newConfig.append("credential_id=fake-cred-id");
         j2Config.write(newConfig.toString(), Charset.defaultCharset().name());
+
+        FilePath poolConfig = cr.getWorkTree().child("config");
+        newConfig = new StringBuilder(poolConfig.readToString());
+        newConfig.append("credential_id= ");
+        poolConfig.write(newConfig.toString(), Charset.defaultCharset().name());
+
         cr.add("*");
         cr.commit("Break it!");
         Updater.getInstance().doRun();
 
         Pool pool = Pool.getInstance();
-        boolean found = false;
-        for(ExecutorJenkins jenkins : pool.getConfig().getJenkinses()) {
-            if(!jenkins.getName().equals("jenkins2"))
-                continue;
 
-            assertNotNull(jenkins.getCredentialId());
-            UsernamePasswordCredentials creds0 = pool.getExecutorCredential(jenkins);
-            assertNull(creds0);
-            found=true;
-        }
-        // we should fail if jenkins2 was not found for any reason
-        assertTrue(found);
+        assertFalse(pool.getConfig().getConfig().containsKey("credential_id"));
+
+        ExecutorJenkins jenkins = pool.getConfig().getJenkinsByName("jenkins1");
+        assertNull(jenkins.getCredentialId());
+
+        jenkins = pool.getConfig().getJenkinsByName("jenkins2");
+        assertNotNull(jenkins.getCredentialId());
+        UsernamePasswordCredentials creds0 = pool.getExecutorCredential(jenkins);
+        assertNull(creds0);
+
+        assertThat(Pool.ADMIN_MONITOR.getErrors().toString(),
+            containsString("Credentials for node-sharing to jenkins2 not found in Jenkins"));
+        Pool.ADMIN_MONITOR.clear();
     }
+
+    @Test
+    public void getPoolWideCredentialsFromJenkinsBroken() throws Exception {
+        GitClient cr = j.getConfigRepo();
+
+        FilePath poolConfig = cr.getWorkTree().child("config");
+        StringBuilder newConfig = new StringBuilder(poolConfig.readToString());
+        newConfig.append("credential_id=fake-cred-id");
+        poolConfig.write(newConfig.toString(), Charset.defaultCharset().name());
+        cr.add("*");
+        cr.commit("Break it!");
+        Updater.getInstance().doRun();
+
+        Pool pool = Pool.getInstance();
+
+        assertNull(pool.getExecutorCredential(pool.getConfig().getJenkinsByName("jenkins2")));
+        assertThat(Pool.ADMIN_MONITOR.getErrors().toString(),
+            containsString("Pool-Wide credentials 'fake-cred-id' for node-sharing not found in Jenkins."));
+   }
 
     @Test
     public void getSnapshotFailedRemote() throws Exception {

--- a/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/utils/ExternalFixture.java
+++ b/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/utils/ExternalFixture.java
@@ -72,7 +72,7 @@ public @interface ExternalFixture {
     Class<? extends Role>[] roles() default {};
 
     /**
-     * Should we stetup JVM options to pass REST credential
+     * Should we setup JVM options to pass REST credential
      */
     boolean setupEnvCredential() default true;
 

--- a/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/utils/ExternalFixture.java
+++ b/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/utils/ExternalFixture.java
@@ -23,6 +23,8 @@
  */
 package com.redhat.jenkins.nodesharing.utils;
 
+import hudson.Util;
+
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Repeatable;
@@ -69,6 +71,16 @@ public @interface ExternalFixture {
      */
     Class<? extends Role>[] roles() default {};
 
+    /**
+     * Should we stetup JVM options to pass REST credential
+     */
+    boolean setupEnvCredential() default true;
+
+    /**
+     * Pool-Wide credentials to use
+     */
+    String credentialId() default "";
+
     interface Role {}
 
     @Retention(RetentionPolicy.RUNTIME)
@@ -84,9 +96,11 @@ public @interface ExternalFixture {
         private String resource;
         private List<String> injectPlugins = new ArrayList<>();
         private List<Class<? extends Role>> roles = new ArrayList<>();
+        boolean setupEnvCredential = true;
+        private String credentialId;
 
         public static Builder from(ExternalFixture f) {
-            Builder builder = new Builder().setResource(f.resource()).setInjectPlugins(f.injectPlugins()).setRoles(f.roles());
+            Builder builder = new Builder().setResource(f.resource()).setInjectPlugins(f.injectPlugins()).setSetupEnvCredential(f.setupEnvCredential()).setCredentialId(f.credentialId()).setRoles(f.roles());
             builder.name = f.name();
             return builder;
         }
@@ -108,6 +122,16 @@ public @interface ExternalFixture {
 
         public Builder addInjectPlugins(String... injectPlugins) {
             this.injectPlugins.addAll(Arrays.asList(injectPlugins));
+            return this;
+        }
+
+        public Builder setSetupEnvCredential(boolean setupEnvCredential) {
+            this.setupEnvCredential = setupEnvCredential;
+            return this;
+        }
+
+        public Builder setCredentialId(String credentialId) {
+            this.credentialId = Util.fixEmptyAndTrim(credentialId);
             return this;
         }
 
@@ -144,6 +168,14 @@ public @interface ExternalFixture {
                     @SuppressWarnings("unchecked")
                     Class<? extends Role>[] a = new Class[0];
                     return roles.toArray(a);
+                }
+
+                @Override public boolean setupEnvCredential() {
+                    return setupEnvCredential;
+                }
+
+                @Override public String credentialId() {
+                    return credentialId;
                 }
             };
         }

--- a/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/utils/GridRule.java
+++ b/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/utils/GridRule.java
@@ -68,7 +68,7 @@ public class GridRule extends ExternalJenkinsRule {
                     ExternalFixture annotation = fixture.getAnnotation();
                     String name = annotation.name();
                     if (hasRole(annotation, Orchestrator.class)) {
-                        TestUtils.declareOrchestrator(configRepo, fixture.getUri().toString());
+                        TestUtils.declareOrchestrator(configRepo, fixture.getUri().toString(), annotation.credentialId());
                     } else if (hasRole(annotation, Executor.class)) {
                         TestUtils.declareExecutor(configRepo, name, fixture.getUri().toString());
                     }
@@ -116,8 +116,10 @@ public class GridRule extends ExternalJenkinsRule {
     protected List<String> startWithJvmOptions(List<String> defaults, ExternalFixture fixture) {
         if (hasRole(fixture, Orchestrator.class)) {
             defaults.add("-Dcom.redhat.jenkins.nodesharingbackend.Pool.ENDPOINT=" + configRepo.getWorkTree().getRemote());
-            defaults.add("-Dcom.redhat.jenkins.nodesharingbackend.Pool.USERNAME=jerry");
-            defaults.add("-Dcom.redhat.jenkins.nodesharingbackend.Pool.PASSWORD=jerry");
+            if(fixture.setupEnvCredential()) {
+                defaults.add("-Dcom.redhat.jenkins.nodesharingbackend.Pool.USERNAME=jerry");
+                defaults.add("-Dcom.redhat.jenkins.nodesharingbackend.Pool.PASSWORD=jerry");
+            }
         }
         return defaults;
     }

--- a/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/utils/NodeSharingJenkinsRule.java
+++ b/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/utils/NodeSharingJenkinsRule.java
@@ -156,7 +156,7 @@ public class NodeSharingJenkinsRule extends JenkinsRule {
     public GitClient singleJvmGrid(Jenkins jenkins) throws Exception {
         GitClient git = configRepo;
 
-        TestUtils.declareOrchestrator(git, jenkins.getRootUrl());
+        TestUtils.declareOrchestrator(git, jenkins.getRootUrl(), null);
 
         TestUtils.declareExecutors(git, Collections.singletonMap("jenkins1", jenkins.getRootUrl()));
         TestUtils.makeNodesLaunchable(git);

--- a/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/utils/NodeSharingJenkinsRule.java
+++ b/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/utils/NodeSharingJenkinsRule.java
@@ -78,6 +78,7 @@ public class NodeSharingJenkinsRule extends JenkinsRule {
     public static final String USER = "jerry";
 
     private UsernamePasswordCredentials restCred;
+    private UsernamePasswordCredentials poolCred;
     private MockAuthorizationStrategy mas = new MockAuthorizationStrategy();
     private GitClient configRepo;
 
@@ -102,11 +103,18 @@ public class NodeSharingJenkinsRule extends JenkinsRule {
                 mas.grant(Jenkins.ADMINISTER, RestEndpoint.RESERVE).everywhere().to("admin");
                 jenkins.setAuthorizationStrategy(mas);
 
+                SystemCredentialsProvider credentialsProvider = SystemCredentialsProvider.getInstance();
+
                 restCred = new UsernamePasswordCredentialsImpl(
                         CredentialsScope.GLOBAL, getRestCredentialId(), "Testing node sharing credential", USER, USER
                 );
-                SystemCredentialsProvider credentialsProvider = SystemCredentialsProvider.getInstance();
                 credentialsProvider.getCredentials().add(restCred);
+                credentialsProvider.save();
+
+                poolCred = new UsernamePasswordCredentialsImpl(
+                        CredentialsScope.GLOBAL, getPoolCredentialId(), "Testing whole-pool credential", USER, USER
+                );
+                credentialsProvider.getCredentials().add(poolCred);
                 credentialsProvider.save();
 
                 try {
@@ -184,6 +192,13 @@ public class NodeSharingJenkinsRule extends JenkinsRule {
     }
     public String getRestCredentialId() {
         return "rest-cred-id";
+    }
+
+    public UsernamePasswordCredentials getPoolCredential() {
+        return poolCred;
+    }
+    public String getPoolCredentialId() {
+        return "pool-cred-id";
     }
 
     public List<ReservationTask> getQueuedReservations() {

--- a/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/utils/TestUtils.java
+++ b/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/utils/TestUtils.java
@@ -28,6 +28,7 @@ import com.redhat.jenkins.nodesharingfrontend.SharedNode;
 import com.redhat.jenkins.nodesharingfrontend.SharedNodeFactory;
 import hudson.EnvVars;
 import hudson.FilePath;
+import hudson.Util;
 import hudson.remoting.Which;
 import hudson.slaves.CommandLauncher;
 import hudson.util.StreamTaskListener;
@@ -69,8 +70,17 @@ public class TestUtils {
         return git;
     }
 
-    public static void declareOrchestrator(GitClient git, String jenkinsUrl) throws IOException, InterruptedException {
-        git.getWorkTree().child("config").write("orchestrator.url=" + jenkinsUrl + System.lineSeparator() + "enforce_https=false", "UTF-8");
+    public static void declareOrchestrator(GitClient git, String jenkinsUrl, String credentialId) throws IOException, InterruptedException {
+        StringBuilder sb = new StringBuilder("orchestrator.url=");
+        sb.append(jenkinsUrl);
+        sb.append(System.lineSeparator());
+        sb.append("enforce_https=false");
+        if(Util.fixEmptyAndTrim(credentialId) != null) {
+            sb.append(System.lineSeparator());
+            sb.append("credential_id=");
+            sb.append(Util.fixEmptyAndTrim(credentialId));
+        }
+        git.getWorkTree().child("config").write(sb.toString(), "UTF-8");
         git.add("config");
         git.commit("Writing config repo orchestrator");
     }

--- a/jth-tests/src/test/resources/com/redhat/jenkins/nodesharing/orchestrator-credential.yaml
+++ b/jth-tests/src/test/resources/com/redhat/jenkins/nodesharing/orchestrator-credential.yaml
@@ -1,0 +1,36 @@
+unclassified:
+  location:
+    url: ${JCASC_SELF_URL}
+
+jenkins:
+  numExecutors: 0
+  quietPeriod: 0
+  slaveAgentPort: -1
+  securityRealm:
+    local:
+      users:
+        - id: "admin"
+          password: "admin"
+        - id: "jerry"
+          password: "jerry"
+  authorizationStrategy:
+    globalMatrix:
+      grantedPermissions:
+      - "Overall/Administer:admin"
+      - "Overall/Read:anonymous"
+      - "Job/Read:anonymous"
+      - "Overall/Read:jerry"
+      - "Job/Read:jerry"
+      - "NodeSharing/Reserve:jerry"
+
+credentials:
+  system:
+    domainCredentials:
+    - credentials:
+      - usernamePassword:
+          scope: SYSTEM
+          id: "rest-cred-id"
+          username: "jerry"
+          password: "jerry"
+          description: "Rest credential for node sharing"
+

--- a/nodesharing-lib/src/main/java/com/redhat/jenkins/nodesharing/ConfigRepo.java
+++ b/nodesharing-lib/src/main/java/com/redhat/jenkins/nodesharing/ConfigRepo.java
@@ -25,6 +25,7 @@ package com.redhat.jenkins.nodesharing;
 
 import hudson.EnvVars;
 import hudson.FilePath;
+import hudson.Util;
 import hudson.plugins.git.GitException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.jenkinsci.plugins.gitclient.Git;
@@ -62,7 +63,7 @@ public class ConfigRepo {
 
     private static final String KEY_JENKINS_URL = "url";
     private static final String KEY_ENFORCE_HTTPS = "enforce_https";
-    private static final String KEY_CREDENTIAL_ID = "credential_id";
+    public static final String KEY_CREDENTIAL_ID = "credential_id";
 
     private static final Logger LOGGER = Logger.getLogger(ConfigRepo.class.getName());
 
@@ -259,8 +260,10 @@ public class ConfigRepo {
             Object key = entry.getKey();
             if (key instanceof String) {
                 Object value = entry.getValue();
-                if (value instanceof  String) {
-                    c.put((String) key, (String) value);
+                if (value instanceof String) {
+                    if(Util.fixEmptyAndTrim((String)value) != null) {
+                        c.put((String) key, (String) value);
+                    }
                 }
             }
         }

--- a/nodesharing-lib/src/main/java/com/redhat/jenkins/nodesharing/ConfigRepo.java
+++ b/nodesharing-lib/src/main/java/com/redhat/jenkins/nodesharing/ConfigRepo.java
@@ -62,6 +62,7 @@ public class ConfigRepo {
 
     private static final String KEY_JENKINS_URL = "url";
     private static final String KEY_ENFORCE_HTTPS = "enforce_https";
+    private static final String KEY_CREDENTIAL_ID = "credential_id";
 
     private static final Logger LOGGER = Logger.getLogger(ConfigRepo.class.getName());
 
@@ -216,6 +217,8 @@ public class ConfigRepo {
 
             String name = jenkinsfile.getName();
             String url = config.get(KEY_JENKINS_URL);
+            String credential_id = config.get(KEY_CREDENTIAL_ID);
+
             if (url == null) {
                 taskLog.error("Jenkins config file " + name + " has no url property");
                 continue;
@@ -232,7 +235,7 @@ public class ConfigRepo {
                 continue;
             }
 
-            jenkinses.add(new ExecutorJenkins(url, name));
+            jenkinses.add(new ExecutorJenkins(url, name, credential_id));
         }
         return Collections.unmodifiableSet(jenkinses);
     }

--- a/nodesharing-lib/src/main/java/com/redhat/jenkins/nodesharing/ExecutorJenkins.java
+++ b/nodesharing-lib/src/main/java/com/redhat/jenkins/nodesharing/ExecutorJenkins.java
@@ -42,9 +42,10 @@ public class ExecutorJenkins {
 
     private final @Nonnull URL url;
     private final @Nonnull String name;
+    private final String credentialId;
     private /*final once initialized*/ @CheckForNull RestEndpoint rest;
 
-    public ExecutorJenkins(@Nonnull String url, @Nonnull String name) {
+    public ExecutorJenkins(@Nonnull String url, @Nonnull String name, String credentialId) {
         try {
             Jenkins.checkGoodName(name);
             this.name = name;
@@ -60,8 +61,12 @@ public class ExecutorJenkins {
         } catch (MalformedURLException|URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }
+        this.credentialId = credentialId;
     }
 
+    public ExecutorJenkins(@Nonnull String url, @Nonnull String name) {
+        this(url, name, null);
+    }
     // Make safe and readable name from URL
     public static String inferCloudName(String url) {
         // This is awfully long, especially for node names
@@ -75,6 +80,10 @@ public class ExecutorJenkins {
 
     public @Nonnull URL getUrl() {
         return url;
+    }
+
+    public String getCredentialId() {
+        return credentialId;
     }
 
     /**
@@ -98,7 +107,7 @@ public class ExecutorJenkins {
 
         ExecutorJenkins that = (ExecutorJenkins) o;
         try {
-            return Objects.equals(name, that.name) && Objects.equals(url.toURI(), that.url.toURI());
+            return Objects.equals(name, that.name) && Objects.equals(url.toURI(), that.url.toURI()) && Objects.equals(credentialId, that.credentialId);
         } catch (URISyntaxException e) {
             throw new AssertionError(e);
         }

--- a/nodesharing-lib/src/main/java/com/redhat/jenkins/nodesharing/ExecutorJenkins.java
+++ b/nodesharing-lib/src/main/java/com/redhat/jenkins/nodesharing/ExecutorJenkins.java
@@ -24,6 +24,7 @@
 package com.redhat.jenkins.nodesharing;
 
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
+import hudson.Util;
 import hudson.model.Failure;
 import jenkins.model.Jenkins;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -42,7 +43,7 @@ public class ExecutorJenkins {
 
     private final @Nonnull URL url;
     private final @Nonnull String name;
-    private final String credentialId;
+    private final @CheckForNull String credentialId;
     private /*final once initialized*/ @CheckForNull RestEndpoint rest;
 
     public ExecutorJenkins(@Nonnull String url, @Nonnull String name, String credentialId) {
@@ -61,7 +62,7 @@ public class ExecutorJenkins {
         } catch (MalformedURLException|URISyntaxException e) {
             throw new IllegalArgumentException(e);
         }
-        this.credentialId = credentialId;
+        this.credentialId = Util.fixEmptyAndTrim(credentialId);
     }
 
     public ExecutorJenkins(@Nonnull String url, @Nonnull String name) {
@@ -82,7 +83,7 @@ public class ExecutorJenkins {
         return url;
     }
 
-    public String getCredentialId() {
+    public @CheckForNull String getCredentialId() {
         return credentialId;
     }
 
@@ -116,7 +117,7 @@ public class ExecutorJenkins {
     @Override
     public int hashCode() {
         try {
-            return Objects.hash(url.toURI(), name);
+            return Objects.hash(url.toURI(), name, credentialId);
         } catch (URISyntaxException e) {
             throw new AssertionError(e);
         }

--- a/nodesharing-lib/src/test/java/com/redhat/jenkins/nodesharing/ExecutorJenkinsTest.java
+++ b/nodesharing-lib/src/test/java/com/redhat/jenkins/nodesharing/ExecutorJenkinsTest.java
@@ -34,6 +34,7 @@ public class ExecutorJenkinsTest {
 
     private static final String VALID_URL = "https://as.df:8080/orchestrator/";
     private static final String VALID_NAME = "as.df";
+    private static final String CREDENTIALS_ID = "some-creds";
 
     @Test(expected = IllegalArgumentException.class)
     public void notAnUrl() throws Exception {
@@ -60,6 +61,10 @@ public class ExecutorJenkinsTest {
         assertEquals(valid, new ExecutorJenkins(VALID_URL, VALID_NAME));
         assertNotEquals(valid, new ExecutorJenkins(VALID_URL + "a", VALID_NAME));
         assertNotEquals(valid, new ExecutorJenkins(VALID_URL, VALID_NAME + "a"));
+        assertNotEquals(valid, new ExecutorJenkins(VALID_URL, VALID_NAME + "a", CREDENTIALS_ID));
+        valid = new ExecutorJenkins(VALID_URL, VALID_NAME, CREDENTIALS_ID);
+        assertNotEquals(valid, new ExecutorJenkins(VALID_URL, VALID_NAME + "a"));
+        assertEquals(valid, new ExecutorJenkins(VALID_URL, VALID_NAME, CREDENTIALS_ID));
     }
 
 //    @Test


### PR DESCRIPTION
Allow user to configure and use credential defined in Credentials. With
that you don't need to specify username and password as JVM parameter.

Signed-off-by: Artur Harasimiuk <artur.harasimiuk@intel.com>