### PR TITLE
[RFC] carry-on cookies with crumb token

### DIFF
--- a/nodesharing-lib/src/main/java/com/redhat/jenkins/nodesharing/transport/CrumbResponse.java
+++ b/nodesharing-lib/src/main/java/com/redhat/jenkins/nodesharing/transport/CrumbResponse.java
@@ -23,9 +23,6 @@
  */
 package com.redhat.jenkins.nodesharing.transport;
 
-import java.util.List;
-import java.util.ArrayList;
-
 import javax.annotation.Nonnull;
 
 /**
@@ -39,12 +36,10 @@ public class CrumbResponse extends Entity {
 
     private final @Nonnull String crumb;
     private final @Nonnull String crumbRequestField;
-    private List<String> cookies;
 
     public CrumbResponse(@Nonnull String crumb, @Nonnull String crumbRequestField) {
         this.crumb = crumb;
         this.crumbRequestField = crumbRequestField;
-        this.cookies = new ArrayList<String>();
     }
 
     public @Nonnull String getCrumb() {
@@ -53,19 +48,5 @@ public class CrumbResponse extends Entity {
 
     public @Nonnull String getCrumbRequestField() {
         return crumbRequestField;
-    }
-
-    public List<String> getCookies() {
-        if(this.cookies == null) {
-            return new ArrayList<String>();
-        }
-        return this.cookies;
-    }
-
-    public void addCookie(String value) {
-        if(this.cookies == null) {
-            this.cookies = new ArrayList<String>();
-        }
-        this.cookies.add(value);
     }
 }

--- a/nodesharing-lib/src/main/java/com/redhat/jenkins/nodesharing/transport/CrumbResponse.java
+++ b/nodesharing-lib/src/main/java/com/redhat/jenkins/nodesharing/transport/CrumbResponse.java
@@ -23,6 +23,9 @@
  */
 package com.redhat.jenkins.nodesharing.transport;
 
+import java.util.List;
+import java.util.ArrayList;
+
 import javax.annotation.Nonnull;
 
 /**
@@ -36,10 +39,12 @@ public class CrumbResponse extends Entity {
 
     private final @Nonnull String crumb;
     private final @Nonnull String crumbRequestField;
+    private List<String> cookies;
 
     public CrumbResponse(@Nonnull String crumb, @Nonnull String crumbRequestField) {
         this.crumb = crumb;
         this.crumbRequestField = crumbRequestField;
+        this.cookies = new ArrayList<String>();
     }
 
     public @Nonnull String getCrumb() {
@@ -48,5 +53,19 @@ public class CrumbResponse extends Entity {
 
     public @Nonnull String getCrumbRequestField() {
         return crumbRequestField;
+    }
+
+    public List<String> getCookies() {
+        if(this.cookies == null) {
+            return new ArrayList<String>();
+        }
+        return this.cookies;
+    }
+
+    public void addCookie(String value) {
+        if(this.cookies == null) {
+            this.cookies = new ArrayList<String>();
+        }
+        this.cookies.add(value);
     }
 }


### PR DESCRIPTION
The problem is that there can be HTTP 403 error when CSRF is enabled on orchestrator and/or executor jenkinses. Solution is quite simple, keep cookies when requesting for crumb token and pass them in next request.
This PR shows what I was able to craft in a sort time. Please share your feedback and let me know if this direction looks ok for you. Additional tests may be required but I haven't looked at this yet.

Signed-off-by: Artur Harasimiuk <artur.harasimiuk@intel.com>