### PR TITLE
Remove usage of `--ajp13Port`

### DIFF
--- a/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/utils/ExternalJenkinsRule.java
+++ b/jth-tests/src/test/java/com/redhat/jenkins/nodesharing/utils/ExternalJenkinsRule.java
@@ -320,7 +320,7 @@ public class ExternalJenkinsRule implements TestRule {
             procArgs.addAll(startWithJvmOptions(new ArrayList<>(), fixture));
             procArgs.add("-jar");
             procArgs.add(jenkinsWar.getAbsolutePath());
-            procArgs.addAll(startWithJenkinsArguments(Lists.newArrayList("--httpPort=" + port, "--ajp13Port=-1"), fixture));
+            procArgs.addAll(startWithJenkinsArguments(Lists.newArrayList("--httpPort=" + port), fixture));
 
             EnvVars envVars = new EnvVars(
                     "jenkins.install.state", "TEST",


### PR DESCRIPTION
AJP support was removed in Jetty 9 and Winstone 3.0 in https://github.com/jenkinsci/winstone/pull/22, never to return. As a result it is pointless to keep setting this option.