### PR TITLE
Use `jenkins.baseline` to reduce bom update mistakes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <dependencies>
       <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
-          <artifactId>bom-2.375.x</artifactId>
+          <artifactId>bom-${jenkins.baseline}.x</artifactId>
           <version>1841.v7b_22c5218e1a</version>
           <scope>import</scope>
           <type>pom</type>
@@ -196,7 +196,9 @@
   </scm>
 
   <properties>
-	  <jenkins.version>2.375.3</jenkins.version>
+    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+    <jenkins.baseline>2.375</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <java.level>11</java.level>
     <concurrency>0.5C</concurrency>
     <surefire.useFile>false</surefire.useFile>


### PR DESCRIPTION
## Use `jenkins.baseline` in `pom.xml`

This change is proposed by the plugin archetype and makes maintenance of `jenkins.version` and `bom` a little easier.

### Testing done

None. Rely on `ci.jenkins.io` to test it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
